### PR TITLE
Fix Postgres links, improve instructions

### DIFF
--- a/lab02/notebook_02_duckdb.ipynb
+++ b/lab02/notebook_02_duckdb.ipynb
@@ -1,52 +1,38 @@
 {
  "cells": [
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "fc1a78ee-5fa1-4ea1-8da6-4d5e82fa48b8",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    }
-   },
-   "source": [
-    "# DuckDB and file formats"
-   ]
+   "source": "# DuckDB and file formats",
+   "id": "396294ac6ba1cd80"
   },
   {
-   "cell_type": "markdown",
-   "id": "86a250cc-1273-4eb6-969e-d77eafd73739",
    "metadata": {},
-   "source": [
-    "This tutorial is slightly based on the DuckDB [tutorial](https://duckdb.org/2024/05/31/analyzing-railway-traffic-in-the-netherlands.html)."
-   ]
+   "cell_type": "markdown",
+   "source": "This tutorial is slightly based on the DuckDB [tutorial](https://duckdb.org/2024/05/31/analyzing-railway-traffic-in-the-netherlands.html).",
+   "id": "642797aeee7dd3c7"
   },
   {
-   "cell_type": "markdown",
-   "id": "cdcf24e0-2938-4fbc-a5be-de4b98c02110",
    "metadata": {},
-   "source": [
-    "## Reading from files"
-   ]
+   "cell_type": "markdown",
+   "source": "## Reading from files",
+   "id": "fd3ba288e75e8165"
   },
   {
-   "cell_type": "markdown",
-   "id": "f1b2674c-a7ff-468e-875b-ea47fa4cad99",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "The only thing needed to run DuckDB is importing it. To compare with Postgres, we will read the CSV file with train services in 2024.\n",
     "\n",
     "By the way, it's highly recommended to always use multi-line strings in triple quotes for all queries, even the simplest ones. It makes them more readable, easier to modify, and removes escaping quotes."
-   ]
+   ],
+   "id": "e744a6f80f55e1e3"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "64b85715-0ccf-45e0-ba41-3a8103ea2f17",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import duckdb\n",
     "\n",
@@ -54,28 +40,26 @@
     "SELECT *\n",
     "FROM \"data/services-2024.csv\"\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "1654b6a21c75fa78"
   },
   {
-   "cell_type": "markdown",
-   "id": "9e1fcdcc-cea5-4de0-bc33-f1e39d872ff6",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "Now that was fast and easy! DuckDB parses CSV and infers type with [quite advanced features](https://duckdb.org/docs/stable/data/csv/auto_detection.html). You can also specify options manually ([documentation](https://duckdb.org/docs/stable/data/csv/overview.html)), e.g.:\n",
     "\n",
     "`FROM read_csv(\"flights.csv\", delim = \"|\")`.\n",
     "\n",
     "Jupyter Notebook automatically prints the results, but we could also save them and call `.show()` explicitly. It is returned as `DuckDBPyRelation` object ([documentation](https://duckdb.org/docs/stable/clients/python/reference/#duckdb.DuckDBPyRelation)). You can use the object-oriented Relational API ([documentation](https://duckdb.org/docs/stable/clients/python/relational_api.html)) instead of writing SQL to compose queries based on Python language constructs. It's less popular than SQL though, and can be less readable."
-   ]
+   ],
+   "id": "30de8b965ab70543"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4229d5ae-8736-4187-8dbe-af184bddfa2a",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "results = duckdb.sql(\"\"\"\n",
     "SELECT *\n",
@@ -83,16 +67,14 @@
     "\"\"\")\n",
     "print(type(results))\n",
     "results.show()"
-   ]
+   ],
+   "id": "bfabb3ee9fe0814f"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "33383868-d7b8-48f4-bcd2-dc1ca4dfdd19",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# last 10 rows\n",
     "duckdb.sql(\"\"\"\n",
@@ -101,14 +83,14 @@
     "ORDER BY \"Service:Date\"\n",
     "LIMIT 10\n",
     "\"\"\").show()"
-   ]
+   ],
+   "id": "b66f679a641b51f0"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b2f1cc0-6ec9-4bf9-ba23-d5e624906ba6",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# total number of late trains\n",
     "duckdb.sql(\"\"\"\n",
@@ -116,12 +98,12 @@
     "FROM \"data/services-2024.csv\"\n",
     "WHERE \"Stop:Arrival delay\" > 0\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "f09f3b8e2ab96a21"
   },
   {
-   "cell_type": "markdown",
-   "id": "c8f96f56-502a-4937-9c42-82c2430fdda8",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "Queries like above are transient (in-memory). They can temporarily spill data to disk to process larger-than-memory datasets, but don't save results. In particular, each query needs to parse CSV file.\n",
     "\n",
@@ -131,35 +113,35 @@
     "- avoiding reading and parsing files, or downloading remote data\n",
     "\n",
     "Such file holds regular tables, which can be created from other data sources."
-   ]
+   ],
+   "id": "3b9ce2d740762429"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8b1e1a59-5e34-42b4-9c0f-2f06d2acc7f6",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "db = duckdb.connect(\"data/duckdb_trains.db\")\n",
     "db"
-   ]
+   ],
+   "id": "84b6c2a1326a79b2"
   },
   {
-   "cell_type": "markdown",
-   "id": "e951e875-0583-4dd3-be13-b3c1ee3bba33",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "If you call methods on `db` object, they will be run on the database. If you use `duckdb` module, the default in-memory session will be used instead.\n",
     "\n",
     "Let's create table from CSV and compare sizes with on-disk file."
-   ]
+   ],
+   "id": "44c754c48473de75"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6578cd4a-d703-45e0-a14a-113f06ebface",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import os\n",
     "\n",
@@ -173,76 +155,68 @@
     "\n",
     "print(f\"CSV size: {csv_size_mb} MB\")\n",
     "print(f\"DuckDB size: {duckdb_size_mb} MB\")"
-   ]
+   ],
+   "id": "fbe9e5fe01380161"
   },
   {
-   "cell_type": "markdown",
-   "id": "0384fabb-1a73-4bde-be84-de2811155402",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "DuckDB uses many [\"friendly SQL\"](https://duckdb.org/docs/stable/sql/dialect/friendly_sql.html) extensions, which make SQL queries easier to write. They also offer many built-in features and functions. Some of them are DuckDB-exclusive, while others (e.g. PIVOT, UNPIVOT) are commonly adopted by many SQL databases.\n",
     "\n",
     "Above, we use [FROM-first syntax](https://duckdb.org/docs/stable/sql/query_syntax/from.html#from-first-syntax), which allows omitting `SELECT *`. Without it, the query would be `AS SELECT * FROM ...`.\n",
     "\n",
     "It also allows switching order of SELECT and FROM. Many people find this more readable. Let's see this in action."
-   ]
+   ],
+   "id": "5892cb8ab2e4f53"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b3e7ce8-4c15-41af-a456-2042d868c833",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "db.sql(\"FROM services SELECT COUNT(*)\")"
-   ]
+   "execution_count": null,
+   "source": "db.sql(\"FROM services SELECT COUNT(*)\")",
+   "id": "6619f7d5ed235fae"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "bc4ae854-b8d5-44f2-8515-36d960a21567",
-   "metadata": {},
-   "source": [
-    "Another friendly SQL extension is [DESCRIBE](https://duckdb.org/docs/stable/guides/meta/describe.html), which provides a summary of table columns, data types, and their basic features. It's very useful to verify the data after loading CSV or other unreliable formats. It even allows skipping SELECT and FROM altogether."
-   ]
+   "source": "Another friendly SQL extension is [DESCRIBE](https://duckdb.org/docs/stable/guides/meta/describe.html), which provides a summary of table columns, data types, and their basic features. It's very useful to verify the data after loading CSV or other unreliable formats. It even allows skipping SELECT and FROM altogether.",
+   "id": "2142aaa94612c94f"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "897ffe42-3fb6-46c7-9c4a-075d3798abbd",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
-   "source": [
-    "db.sql(\"DESCRIBE services\")"
-   ]
+   "execution_count": null,
+   "source": "db.sql(\"DESCRIBE services\")",
+   "id": "5089e6472619ea30"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "Let's see a few examples of queries on this table:",
-   "id": "cdce677dd54559d1"
+   "id": "aa504d497058d084"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9606e812",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# number of all the services\n",
     "db.sql(\"\"\"\n",
     "SELECT COUNT(DISTINCT \"Service:RDT-ID\") \n",
     "FROM services\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "ea9c7ef5083d057b"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a447df3f",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# number of stops per service\n",
     "db.sql(\"\"\"\n",
@@ -253,14 +227,14 @@
     "ORDER BY num_stops DESC\n",
     "\"\"\"\n",
     ")"
-   ]
+   ],
+   "id": "d34d1bd37be6e314"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b1f85fbb",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# average arrival delay per service type\n",
     "db.sql(\"\"\"\n",
@@ -271,12 +245,12 @@
     "GROUP BY \"Service:Type\"\n",
     "ORDER BY avg_arrival_delay DESC\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "e53897888743d1a9"
   },
   {
-   "cell_type": "markdown",
-   "id": "0c9ce6df-2e58-48d9-b16e-fff5cf6cc34a",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "**Exercises**\n",
     "\n",
@@ -284,42 +258,38 @@
     "2. Load file `data/disruptions-2023.csv` as `disruptions` table. Describe it.\n",
     "3. What were the 5 most frequent disruption causes in 2023, and how many times did they occur?\n",
     "4. Select the row with the longest disruption. What was the cause? How long was it in days?"
-   ]
+   ],
+   "id": "ab9a869805e1be45"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "706864cf-7c09-4893-a3cf-336ad88cba65",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
-   "source": []
+   "execution_count": null,
+   "source": "",
+   "id": "9f083e3c6bf9d808"
   },
   {
-   "cell_type": "markdown",
-   "id": "96451233-1aaa-4dba-83b1-1094a414dd7d",
    "metadata": {},
-   "source": [
-    "## Connecting to databases"
-   ]
+   "cell_type": "markdown",
+   "source": "## Connecting to databases",
+   "id": "f6762bed38d8c7bd"
   },
   {
-   "cell_type": "markdown",
-   "id": "aad30a8a-466b-43c6-b378-359aee8a0756",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "DuckDB can connect to various data sources, e.g. Excel, databases, cloud files, data lakehouses, and others. It uses a system of [extensions](https://duckdb.org/docs/stable/extensions/overview), which are loaded explicitly. This avoids bloating the base package and is very flexible. We will now install and load the Postgres extension, and query the database.\n",
     "\n",
     "Make sure that PostgreSQL is up and running in Docker Compose."
-   ]
+   ],
+   "id": "b7eba5829383d837"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65377fb6-53cd-43fe-96da-69cb4dfab533",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# install and import extension\n",
     "db.sql(\"\"\"INSTALL postgres; LOAD postgres;\"\"\")\n",
@@ -332,124 +302,116 @@
     "db.sql(f\"\"\"\n",
     "ATTACH IF NOT EXISTS '{conn_string}' AS postgres_db_read (TYPE postgres, READ_ONLY);\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "5a8cb87116a63ae1"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2be0c6a5-1a0e-43f8-9720-137d1dbcb140",
-   "metadata": {
-    "scrolled": true
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# command to list all tables available\n",
     "db.sql(\"SHOW ALL TABLES\")"
-   ]
+   ],
+   "id": "ba5a7dc6eead8860"
   },
   {
-   "cell_type": "markdown",
-   "id": "55238326-00fd-4c2c-a2b3-0687bf8dff58",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "You can securely store connections information in [DuckDB secrets](https://duckdb.org/docs/stable/core_extensions/postgres#configuring-via-secrets). Here, we make a read-only connection, but DuckDB can also [write to Postgres](https://duckdb.org/docs/stable/core_extensions/postgres#writing-data-to-postgresql). This way you can e.g. insert Parquet data into Postgres, which is not supported natively.\n",
     "\n",
     "When a database is attached, the data is queried from it each time. It guarantees the newest data, but also results in networking overhead. You can [copy Postgres table](https://duckdb.org/docs/stable/core_extensions/postgres#usage) into DuckDB to avoid this, but you have stale data this way.\n",
     "\n",
     "We have two `services` tables now - to query the Postgres one, we prefix it with database alias. Compare querying Postgres and DuckDB tables."
-   ]
+   ],
+   "id": "d43566a0176fed07"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d92dddf4-9f84-4e8f-9a4d-de40ac863720",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "db.sql(\"\"\"\n",
     "SELECT COUNT(*)\n",
     "FROM postgres_db_read.services\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "dca32fa882592aca"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db21a89b-aab2-41df-9515-1efb1d951a24",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "db.sql(\"\"\"\n",
     "SELECT COUNT(*)\n",
     "FROM services\n",
     "\"\"\")"
-   ]
+   ],
+   "id": "79cb1749e041e19"
   },
   {
-   "cell_type": "markdown",
-   "id": "febaae58-038c-49e4-b1ed-d21fd08221a3",
    "metadata": {},
-   "source": [
-    "You can run any queries this way, e.g. JOIN files and databases, insert and update data sources, and more. To remove a database, use DETACH command:"
-   ]
+   "cell_type": "markdown",
+   "source": "You can run any queries this way, e.g. JOIN files and databases, insert and update data sources, and more. To remove a database, use DETACH command:",
+   "id": "443b225d7042bad"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a6f4a2dc-278e-4e3d-8979-996eebba1e8d",
-   "metadata": {},
    "outputs": [],
-   "source": [
-    "db.sql(\"DETACH postgres_db_read\")"
-   ]
+   "execution_count": null,
+   "source": "db.sql(\"DETACH postgres_db_read\")",
+   "id": "4d7e115c39252956"
   },
   {
-   "cell_type": "markdown",
-   "id": "4db17c74-5822-43c9-bb8d-43c1e111f842",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "**Exercise**\n",
     "\n",
     "1. Download data about disruptions from 2024 ([Rijden de Treinen page](https://www.rijdendetreinen.nl/en/open-data/disruptions)). You can use either Python (e.g. [urllib](https://stackoverflow.com/a/19602990/9472066)) or wget.\n",
     "2. Create read-write connection to Postgres.\n",
-    "3. Use [Postgres CREATE TABLE](https://duckdb.org/docs/stable/extensions/postgres.html#create-table) in DuckDB to insert both 2023 and 2024 disruptions data into Postgres database as `disruptions` table. See [documentation about reading multiple files](https://duckdb.org/docs/stable/data/multiple_files/overview.html).\n",
+    "3. Use [Postgres CREATE TABLE](https://duckdb.org/docs/stable/core_extensions/postgres#create-table) in DuckDB to insert both 2023 and 2024 disruptions data into Postgres database as `disruptions` table. See [documentation about reading multiple files](https://duckdb.org/docs/stable/data/multiple_files/overview.html).\n",
     "4. Query how many disruptions occurred in 2023 and 2024."
-   ]
+   ],
+   "id": "87a83a19a5782001"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d6d3d329-165b-4920-8f5a-ac1c0214855a",
-   "metadata": {},
    "outputs": [],
-   "source": []
+   "execution_count": null,
+   "source": "",
+   "id": "384c94f459ef0f31"
   },
   {
-   "cell_type": "markdown",
-   "id": "67ea8a8e-99c9-478b-bf91-4d1cb6278ba3",
    "metadata": {},
-   "source": [
-    "## Writing data"
-   ]
+   "cell_type": "markdown",
+   "source": "## Writing data",
+   "id": "304f880cf20ee7a6"
   },
   {
-   "cell_type": "markdown",
-   "id": "18694e7a-60f4-452a-80f1-02ef7128bb4e",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "DuckDB can not only insert data into databases, but also write regular files to disk, for example [JSON and JSON Lines](https://duckdb.org/docs/stable/data/json/writing_json) and [Parquet](https://duckdb.org/docs/stable/data/parquet/overview). It also makes it very convenient as a format conversion tool, e.g. as a first part in a data processing workflow.\n",
     "\n",
     "DuckDB is very fast at reading CSV, and [gets faster over time](https://duckdb.org/2024/06/26/benchmarks-over-time.html#csv-reader). However, its unique feature is [very robust and advanced CSV parsing](https://duckdb.org/2023/10/27/csv-sniffer.html), based on paper [\"Multiple hypothesis CSV parsing\" T. Döhmen et al.](https://hannes.muehleisen.org/publications/ssdbm2017-muehleisen-csvs.pdf), and in case of errors it has [verbose error informations](https://duckdb.org/docs/stable/data/csv/reading_faulty_csv_files), as well as option to omit faulty lines.\n",
     "\n",
     "Let's read the CSV file with 2024 train services and change it to TSV (tab-separated values) file. Exporting files also uses COPY command, with format-specific options ([documentation](https://duckdb.org/docs/stable/sql/statements/copy.html#csv-options))."
-   ]
+   ],
+   "id": "53374a64fc29e9a7"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1474ef5c-3615-48b4-95a6-7b84f5899c02",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "duckdb.sql(\"\"\"\n",
     "COPY (SELECT * FROM \"data/services-2024.csv\") TO \"data/services_2024_duckdb.tsv\" (HEADER, DELIMITER \"\\t\");\n",
@@ -462,40 +424,38 @@
     "        print(line)\n",
     "        if i == 5:\n",
     "            break"
-   ]
+   ],
+   "id": "99fb1942351a49d5"
   },
   {
-   "cell_type": "markdown",
-   "id": "0894db81-7f8b-4617-961d-6e013115b25e",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "**Exercise**\n",
     "\n",
     "1. Convert the 2024 services file into JSON, JSON Lines and Parquet files. Use ZSTD compression for Parquet. Use [DuckDB documentation](https://duckdb.org/docs/stable/sql/statements/copy.html#format-specific-options).\n",
     "2. Compare file size of each file format (including CSV) in MB.\n",
     "3. Compare loading time of each file format (including CSV), e.g. to count how many trains arrived at Rotterdam Centraal station. Use `time` module. Report mean time of 3 repetitions."
-   ]
+   ],
+   "id": "94c67b291d788cee"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "866bb448-26c7-4e93-b27c-1594968f2d78",
-   "metadata": {},
    "outputs": [],
-   "source": []
+   "execution_count": null,
+   "source": "",
+   "id": "272e9cc645521f9c"
   },
   {
-   "cell_type": "markdown",
-   "id": "c9f18a0f-9b7f-4d2a-9813-778d8b1305c6",
    "metadata": {},
-   "source": [
-    "## DuckDB interoperability"
-   ]
+   "cell_type": "markdown",
+   "source": "## DuckDB interoperability",
+   "id": "b69c921237b858ea"
   },
   {
-   "cell_type": "markdown",
-   "id": "30503632-321c-4e49-ad37-dc35f3acb1f7",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "DuckDB is highly interoperable with Python and with data processing frameworks like Pandas and Polars. It can convert results to them, as well as query DataFrames with SQL. This has a few uses:\n",
     "- switch to SQL whenever you want\n",
@@ -506,14 +466,14 @@
     "Getting results in Python works similarly to `psycopg`, with methods `.fetchone()` and `.fetchall()`.\n",
     "\n",
     "Let's see how many services were run in January and December 2024."
-   ]
+   ],
+   "id": "efacc68e06fbbbd1"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39b810aa-956c-4fbf-8258-7c24f86f9fd2",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "num_jan_services = duckdb.sql(\"\"\"\n",
     "SELECT COUNT(DISTINCT \"Service:RDT-ID\")\n",
@@ -531,22 +491,20 @@
     "\n",
     "print(f\"January services: {num_jan_services}\")\n",
     "print(f\"December services: {num_dec_services}\")"
-   ]
+   ],
+   "id": "a77081df9830e7dc"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "e38253fe-76af-41f3-8f2f-4d767c2e5fda",
-   "metadata": {},
-   "source": [
-    "Converting to Pandas is similar, with method `.to_df()` (aliases: `.fetch_df()`, `.df()`). Let's fetch all services by month."
-   ]
+   "source": "Converting to Pandas is similar, with method `.to_df()` (aliases: `.fetch_df()`, `.df()`). Let's fetch all services by month.",
+   "id": "d5e2a00121168c0e"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9ed1557-fcc6-4de7-91c9-3e555f7e7da1",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "num_monthly_services = duckdb.sql(\"\"\"\n",
     "SELECT MONTH(\"Service:Date\") AS month, COUNT(DISTINCT \"Service:RDT-ID\") AS num_services \n",
@@ -556,42 +514,38 @@
     "\"\"\").df()\n",
     "\n",
     "num_monthly_services"
-   ]
+   ],
+   "id": "ef311b64ba32d06e"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "835949bc-e95e-49c9-a8dc-aba5fb762144",
-   "metadata": {},
-   "source": [
-    "Since we're already here, let's visualize this with Matplotlib. Pandas has handy shortcuts in `.plot` method ([documentation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.html))."
-   ]
+   "source": "Since we're already here, let's visualize this with Matplotlib. Pandas has handy shortcuts in `.plot` method ([documentation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.html)).",
+   "id": "8538855cf0c1d9e1"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "603ef954-be62-42a0-9c02-cde597281a22",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "num_monthly_services.plot.line(\n",
     "    x=\"month\", y=\"num_services\", title=\"Number of services in 2024 by month\"\n",
     ")"
-   ]
+   ],
+   "id": "81b7494fe2b4509"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "13f75c4e-eecf-4882-9b27-f0a11fd1b178",
-   "metadata": {},
-   "source": [
-    "We can also query Pandas DataFrames by just using variable names like tables. Note that we should use Arrow backend for good performance here. Let's load the disruptions from 2023 and check for frequency of top 10 most popular causes. Then we will go back to Pandas and make a bar plot."
-   ]
+   "source": "We can also query Pandas DataFrames by just using variable names like tables. Note that we should use Arrow backend for good performance here. Let's load the disruptions from 2023 and check for frequency of top 10 most popular causes. Then we will go back to Pandas and make a bar plot.",
+   "id": "6ac6acf04075539"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5ae1efef-389e-4c68-bb68-8050d2591302",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -606,34 +560,35 @@
     "\"\"\").df()\n",
     "\n",
     "df_disruptions_statistics.plot.barh(x=\"cause\", y=\"cause_frequency\")"
-   ]
+   ],
+   "id": "ff8766ca904f6903"
   },
   {
-   "cell_type": "markdown",
-   "id": "d61cf59c-316d-4443-b1a5-78486288b9e6",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "**Exercise**\n",
     "\n",
     "1. Extract the average daily arrival delays of 2024 train services with DuckDB. Note that NULL delay means zero, and you have to use [COALESCE function](https://duckdb.org/docs/stable/sql/functions/utility.html#coalesceexpr-) to fill them as zeros.\n",
     "2. Visualize those changes over time with Pandas on a line plot. Plot daily average, and also rolling mean (average) of 7 and 30 days to analyze longer trends."
-   ]
+   ],
+   "id": "d539c2c7b2b5987e"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cd725613-fec8-40fa-8dab-ab33fbc13ab6",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": []
+   "execution_count": null,
+   "source": "",
+   "id": "c55f0388b19817b1"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65945322-2276-4dbf-8931-d8f2e30217d8",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": []
+   "execution_count": null,
+   "source": "",
+   "id": "212b310faaaaad63"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Two small issues fixed:
1. DuckDB changed URL schema for core extensions - Postgres was moved from `/docs/stable/extensions` to /docs/stable/core_extensions`.

2. In one of the excercises years were mixed.