### PR TITLE
Lab6 Removed problematic index resetting

### DIFF
--- a/lab06/LAB_INSTRUCTION.ipynb
+++ b/lab06/LAB_INSTRUCTION.ipynb
@@ -517,7 +517,6 @@
     "df[\"text_lower\"] = df[\"text\"].str.lower()\n",
     "df_deduplicated = df.drop_duplicates(subset=\"text_lower\")\n",
     "df_deduplicated = df_deduplicated.drop(columns=\"text_lower\")\n",
-    "df_deduplicated = df_deduplicated.reset_index(drop=True)\n",
     "df_deduplicated"
    ]
   },


### PR DESCRIPTION
Markdown text above says "Note that we will keep the index to avoid recalculation for inspecting further issues.". In my understanding we should reset indexes. I might be wrong tho